### PR TITLE
Renaming Execution Manger to Template Manager

### DIFF
--- a/product/p2-profile-gen/pom.xml
+++ b/product/p2-profile-gen/pom.xml
@@ -310,7 +310,7 @@
                                     org.wso2.carbon.analytics:org.wso2.carbon.analytics.stream.persistence.server.feature:${carbon.analytics.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.analytics-common:org.wso2.carbon.event.execution.manager.feature:${carbon.analytics.common.version}
+                                    org.wso2.carbon.analytics-common:org.wso2.carbon.event.template.manager.feature:${carbon.analytics.common.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.analytics:org.wso2.carbon.analytics.spark.feature:${carbon.analytics.version}
@@ -694,7 +694,7 @@
                                     <version>${carbon.analytics.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.event.execution.manager.feature.group</id>
+                                    <id>org.wso2.carbon.event.template.manager.feature.group</id>
                                     <version>${carbon.analytics.common.version}</version>
                                 </feature>
                                 <feature>


### PR DESCRIPTION
This pull contains changes w.r.t renaming of Execution Manger component to Template Manager. The changes will be incorporated in following versions;
carbon.analytics.common: 5.1.0-SNAPSHOT
carbon.analytics: 1.0.6-SNAPSHOT
carbon.event.processing: 2.1.0-SNAPSHOT

Please review and merge